### PR TITLE
Corrected '(' delimiter in parser. (And simplified some quotes.)

### DIFF
--- a/src/scalaam/scala/language/sexp/SExp.scala
+++ b/src/scalaam/scala/language/sexp/SExp.scala
@@ -7,7 +7,7 @@ import scalaam.core.{Position, Identifier}
   */
 sealed abstract class Value
 case class ValueString(value: String) extends Value {
-  override def toString = "\"" + value + "\""
+  override def toString = '"' + value + '"'
 }
 case class ValueSymbol(sym: String) extends Value {
   override def toString = sym

--- a/src/scalaam/scala/language/sexp/SExpParser.scala
+++ b/src/scalaam/scala/language/sexp/SExpParser.scala
@@ -50,7 +50,7 @@ trait SExpTokens extends Tokens {
     def chars = s
   }
   case class TString(s: String) extends SExpToken {
-    def chars = "\"" + s + "\""
+    def chars = '"' + s + '"'
   }
   case class TInteger(n: Int) extends SExpToken {
     def chars = n.toString
@@ -107,7 +107,7 @@ class SExpLexer extends Lexical with SExpTokens {
   def chr(c: Char): Parser[Char] = elem(s"character $c", _ == c)
   def sign: Parser[Option[Char]] = opt(chr('+') | chr('-'))
   def stringContentNoEscape: Parser[String] =
-    rep(chrExcept('\\', '\"')) ^^ (_.mkString)
+    rep(chrExcept('\\', '"')) ^^ (_.mkString)
   def stringContent: Parser[String] = {
     (stringContentNoEscape ~ '\\' ~ any ~ stringContent ^^ {
       case s1 ~ '\\' ~ c ~ s2 => s"$s1\\$c$s2"
@@ -117,7 +117,7 @@ class SExpLexer extends Lexical with SExpTokens {
 
   /* R5RS: Tokens which require implicit termination (identifiers, numbers, characters, and dot) may be terminated by any <delimiter>, but not necessarily by anything else.  */
   def delimiter: Parser[Unit] =
-    (whitespaceChar | eol | eoi | chr(')') | chr(')') | chr('\"') | chr(';')) ^^ (_ => ())
+    (whitespaceChar | eol | eoi | chr('(') | chr(')') | chr('"') | chr(';')) ^^ (_ => ())
 
   def boolean: Parser[SExpToken] =
     '#' ~> ('t' ^^^ TBoolean(true) | 'f' ^^^ TBoolean(false))
@@ -133,8 +133,8 @@ class SExpLexer extends Lexical with SExpTokens {
   def character: Parser[SExpToken] =
     '#' ~> '\\' ~> any ^^ (c => TCharacter(c))
   def string: Parser[SExpToken] = {
-    ('\"' ~> stringContent ~ chrExcept('\\') <~ '\"' ^^ { case s ~ ending => TString(s + ending) }) |
-      ('\"' ~> stringContent <~ '\"' ^^ (s => TString(s)))
+    ('"' ~> stringContent ~ chrExcept('\\') <~ '"' ^^ { case s ~ ending => TString(s + ending) }) |
+      ('"' ~> stringContent <~ '"' ^^ (s => TString(s)))
   }
   def identifier: Parser[SExpToken] = {
     def specialInitial: Parser[Char] =

--- a/src/scalaam/scala/lattice/ConcreteLattice.scala
+++ b/src/scalaam/scala/lattice/ConcreteLattice.scala
@@ -68,7 +68,7 @@ object Concrete {
     }
 
     implicit val stringShow: Show[String] = new Show[String] {
-      def show(s: String): String = "\"" + s + "\""
+      def show(s: String): String = '"' + s + '"'
     }
     implicit val stringConcrete: StringLattice[S] = new BaseInstance[String]("Str")
     with StringLattice[S] {


### PR DESCRIPTION
There had a typo in list of delimiter. The ')' was two times and '(' was missing.